### PR TITLE
Added PRDLIB and CURLIB to CMD recipe

### DIFF
--- a/src/mk/def_rules.mk
+++ b/src/mk/def_rules.mk
@@ -290,6 +290,8 @@ CMD_HLPPNLGRP = $(basename $@)
 CMD_PGM = $(basename $@)
 CMD_PMTFILE := *NONE
 CMD_VLDCKR := *NONE
+CMD_CURLIB := ${CURLIB}
+CMD_PRDLIB := ${PRDLIB}
 
 CMOD_AUT := $(AUT)
 CMOD_DEFINE := $(DEFINE)
@@ -457,7 +459,7 @@ WSCST_AUT := $(AUT)
 
 # Creation command parameters with variables (the ones listed at the top) for the most common ones.
 CRTCLMODFLAGS = AUT($(AUT)) DBGVIEW($(DBGVIEW)) OPTIMIZE($(OPTIMIZE)) DBGENCKEY($(DBGENCKEY))  OPTION($(OPTION)) TEXT('$(subst ','',$(TEXT))') TGTRLS($(TGTRLS)) INCDIR($(INCDIR))
-CRTCMDFLAGS = VLDCKR($(VLDCKR)) PMTFILE($(PMTFILE)) HLPPNLGRP($(HLPPNLGRP)) HLPID($(HLPID)) AUT($(AUT)) ALLOW($(ALLOW)) $(if $(TEXT),TEXT('$(TEXT)'),)
+CRTCMDFLAGS = VLDCKR($(VLDCKR)) PMTFILE($(PMTFILE)) HLPPNLGRP($(HLPPNLGRP)) HLPID($(HLPID)) AUT($(AUT)) ALLOW($(ALLOW)) $(if $(TEXT),TEXT('$(TEXT)'),) CURLIB($(CURLIB)) PRDLIB($(PRDLIB))
 CRTCMODFLAGS = TERASPACE($(TERASPACE)) STGMDL($(STGMDL)) OUTPUT(*PRINT) OPTION($(OPTION)) DBGVIEW($(DBGVIEW)) OPTIMIZE($(OPTIMIZE)) DBGENCKEY($(DBGENCKEY))  \
                SYSIFCOPT($(SYSIFCOPT)) AUT($(AUT)) TEXT('$(subst ','',$(TEXT))') TGTCCSID($(TGTCCSID)) TGTRLS($(TGTRLS)) INLINE($(INLINE)) INCDIR($(INCDIR)) \
                LOCALETYPE($(LOCALETYPE)) DEFINE($(DEFINE))
@@ -1106,6 +1108,8 @@ define CMDSRC_TO_CMD_RECIPE =
 	$(eval HLPPNLGRP = $(CMD_HLPPNLGRP))
 	$(eval PMTFILE = $(CMD_PMTFILE))
 	$(eval VLDCKR = $(CMD_VLDCKR))
+	$(eval CURLIB = $(CMD_CURLIB))
+	$(eval PRDLIB = $(CMD_PRDLIB))
 	$(eval d = $($@_d))
 	@$(call echo_cmd,"=== Creating command [$(notdir $<)] in $(call ESCAPE_FOR_RECIPE,$(OBJLIB))")
 	$(eval crtcmd := CRTCMD CMD($(call ESCAPE_FOR_RECIPE,$(OBJLIB))/$(basename $(@F))) \
@@ -1120,6 +1124,8 @@ define CMD_TO_CMD_RECIPE =
 	$(eval HLPPNLGRP = $(CMD_HLPPNLGRP))
 	$(eval PMTFILE = $(CMD_PMTFILE))
 	$(eval VLDCKR = $(CMD_VLDCKR))
+	$(eval CURLIB = $(CMD_CURLIB))
+	$(eval PRDLIB = $(CMD_PRDLIB))
 	$(eval d = $($@_d))
 	@$(call echo_cmd,"=== Creating command [$(notdir $<)] in $(call ESCAPE_FOR_RECIPE,$(OBJLIB))")
 	$(eval crtcmd := CRTCMD CMD($(call ESCAPE_FOR_RECIPE,$(OBJLIB))/$(basename $(@F))) srcstmf('$<') PGM($(call ESCAPE_FOR_RECIPE,$(OBJLIB)/$(CMD_PGM))) $(CRTCMDFLAGS))


### PR DESCRIPTION
This PR adds support for the `PRDLIB` and `CURLIB` parameters to the CMD recipe.