### PR TITLE
Added optional Makefile

### DIFF
--- a/src/mk/Makefile
+++ b/src/mk/Makefile
@@ -73,6 +73,9 @@ $(eval $(value FOOTER))
 # directory.
 -include $(wildcard $(DEPDIR)/*.d)
 
+# Include custom (user defined) Makefile if set
+-include $(TOBI_CUSTOM_MAKEFILE)
+
 # This is just a convenience - to let you know when make has stopped
 # interpreting make files and started their execution.
 # $(info Rules generated $(if $(BUILD_MODE),for "$(BUILD_MODE)" mode,)...)


### PR DESCRIPTION
Currently TOBi can only build/compile code. There is no way to execute custom (user defined) code. By including an optional Makefile the user could execute custom make targets defined in the custom Makefile. Those targets may contain stuff like cleaning up, packaging objects, archiving objects or deploy objects. Everything which can be executed from a shell may be added to those custom targets including call IBM i native commands and program.

### How to execute a custom target?

First the user need to create a Makefile with a custom target. Then the env var TOBI_CUSTOM_MAKEFILE must be set to this Makefile.

```
export TOBI_CUSTOM_MAKEFILE=<path_to_custom_makefile>
```

The custom make target can be executed with the -t option on the build subcommand.

```
makei build -t <custom_target>
```
