### PR TITLE
Added support for creating a file without a member

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+- Added support to create a file without member
 * Thu Mar 12 2026 Het Patel <het.patel@ibm.com> - 3.2.1
 - Added a new feature for IASP support.
 - Fixed Label on Table issue.

--- a/src/mk/def_rules.mk
+++ b/src/mk/def_rules.mk
@@ -187,6 +187,9 @@ endif
 ifndef RCDLEN
 RCDLEN :=
 endif
+ifndef MBR
+MBR :=
+endif
 ifndef REUSEDLT
 REUSEDLT := *NO
 endif
@@ -465,9 +468,9 @@ CRTCPPMODFLAGS = TERASPACE($(TERASPACE)) STGMDL($(STGMDL)) OUTPUT(*PRINT) OPTION
                  SYSIFCOPT($(SYSIFCOPT)) AUT($(AUT)) TEXT('$(subst ','',$(TEXT))') TGTCCSID($(TGTCCSID)) TGTRLS($(TGTRLS)) INLINE($(INLINE)) INCDIR($(INCDIR)) \
                  LOCALETYPE($(LOCALETYPE)) DEFINE($(DEFINE)) USRPRF($(USRPRF))
 CRTDSPFFLAGS = ENHDSP($(ENHDSP)) RSTDSP($(RSTDSP)) DFRWRT($(DFRWRT)) AUT($(AUT)) OPTION($(OPTION)) TEXT('$(subst ','',$(TEXT))')
-CRTLFFLAGS = AUT($(AUT)) OPTION($(OPTION)) TEXT('$(subst ','',$(TEXT))')
+CRTLFFLAGS = AUT($(AUT)) OPTION($(OPTION)) TEXT('$(subst ','',$(TEXT))') $(if $(MBR),MBR($(MBR)),)
 CRTMNUFLAGS = AUT($(AUT)) OPTION($(OPTION)) CURLIB($(CURLIB)) PRDLIB($(PRDLIB)) TEXT('$(subst ','',$(TEXT))') TYPE($(TYPE))
-CRTPFFLAGS = AUT($(AUT)) DLTPCT($(DLTPCT)) OPTION($(OPTION)) REUSEDLT($(REUSEDLT)) SIZE($(SIZE)) ALWUPD($(PF_ALWUPD)) TEXT('$(subst ','',$(TEXT))')
+CRTPFFLAGS = AUT($(AUT)) DLTPCT($(DLTPCT)) OPTION($(OPTION)) REUSEDLT($(REUSEDLT)) SIZE($(SIZE)) ALWUPD($(PF_ALWUPD)) TEXT('$(subst ','',$(TEXT))') $(if $(MBR),MBR($(MBR)),)
 CRTPGMFLAGS = ACTGRP($(ACTGRP)) ALWUPD($(ALWUPD)) USRPRF($(USRPRF)) TGTRLS($(TGTRLS)) AUT($(AUT)) DETAIL($(DETAIL)) OPTION($(CRTPGM_OPTION)) STGMDL($(STGMDL)) TEXT('$(subst ','',$(TEXT))') ALWRINZ($(ALWRINZ))
 CRTPNLGRPFLAGS = AUT($(AUT)) OPTION($(OPTION)) TEXT('$(subst ','',$(TEXT))')
 CRTRPGPGMFLAGS = OPTION($(OPTION)) TEXT('$(subst ','',$(TEXT))') USRPRF($(USRPRF)) TGTRLS($(TGTRLS))
@@ -672,6 +675,12 @@ fileALWUPD = $(strip \
 	$(if $(filter %.PF,$<),$(PF_ALWUPD), \
 	$(if $(filter %.pf,$<),$(PF_ALWUPD), \
 	UNKNOWN_FILE_TYPE)))
+fileMBR = $(strip \
+	$(if $(filter %.PF,$<),$(PF_MBR), \
+	$(if $(filter %.pf,$<),$(PF_MBR), \
+	$(if $(filter %.LF,$<),$(LF_MBR), \
+	$(if $(filter %.lf,$<),$(LF_MBR), \
+	UNKNOWN_FILE_TYPE)))))
 fileTGTRLS = $(strip \
 	$(if $(filter %.table,$<),$(SQL_TGTRLS), \
 	$(if $(filter %.TABLE,$<),$(SQL_TGTRLS), \
@@ -1149,6 +1158,7 @@ define FILE_VARIABLES =
 	$(eval SIZE = $(fileSIZE))\
 	$(eval TGTRLS = $(fileTGTRLS))\
 	$(eval ALWUPD = $(fileALWUPD))\
+	$(eval MBR = $(fileMBR))\
 	$(eval TYPEDEF = $(if $(filter YES,$(CREATE_TYPEDEF)),$(SCRIPTSPATH)/crttypedef "$<" "$@" "$(OBJPATH)",))
 endef
 


### PR DESCRIPTION
Added support for creating a file without a member. To create a file without a member have to explicitly set MBR = *NONE in the Rule.mk for PF and LF files. For example:

```
SIMPLEPF.FILE: private MBR = *NONE
SIMPLEPF.FILE: simple.pf
```
<img width="1318" height="330" alt="image" src="https://github.com/user-attachments/assets/6106c2e5-0ad8-4164-89bb-5f8f14fc3616" />
