### PR TITLE
fix: replace os.popen with subprocess.run in _get_attr to prevent Uni…

### DIFF
--- a/src/makei/cvtsrcpf.py
+++ b/src/makei/cvtsrcpf.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3.9
 # -*- coding: utf-8 -*-
 import os
+import subprocess
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -200,8 +201,9 @@ class CvtSrcPf:
 
 
 def _get_attr(filepath: str, defaultCcsid: str):
-    stream = os.popen(f'/QOpenSys/usr/bin/attr {filepath}')
-    output = stream.read().strip()
+    result = subprocess.run(['/QOpenSys/usr/bin/attr', filepath],
+                           capture_output=True, text=True, errors='replace')
+    output = result.stdout.strip()
     attrs = {"CCSID": defaultCcsid}
     if not output.__contains__("="):
         raise Exception(f"Unable to access '{filepath}' make sure file exists and that the user has permissions to it")


### PR DESCRIPTION
…codeDecodeError

The _get_attr() function uses os.popen() to invoke /QOpenSys/usr/bin/attr, which opens subprocess stdout with Python's default strict UTF-8 decoding. On systems where IFS object attributes contain EBCDIC-origin metadata, the attr command output can include bytes that are not valid UTF-8, causing a UnicodeDecodeError crash.

Replace os.popen() with subprocess.run() using errors='replace' so that non-decodable bytes are substituted with the Unicode replacement character instead of raising an exception. This also eliminates a potential shell injection vector since os.popen(f'...{filepath}') passes through the shell, while subprocess.run([...], filepath) does not.